### PR TITLE
Switched to using @ strategy instead of =

### DIFF
--- a/app/partials/sentence-list.html
+++ b/app/partials/sentence-list.html
@@ -9,7 +9,7 @@
 
   <br><br>
   <!-- expanding progress info bar -->
-  <health-progress class="health-progress" progress-title="title">
+  <health-progress class="health-progress" progress-title='{{title}}'>
     {{text}}
   </health-progress>
 

--- a/app/scripts/directives-health.js
+++ b/app/scripts/directives-health.js
@@ -20,7 +20,7 @@
         // = - data binds property with property in Directive parent scope
         // @ - pass attribute as string and data bind value in enclosing scope using interpolation {{}} in attribute value
         // & - pass in fn from parent scope to be called later
-        scope: { title:'=progressTitle' },
+        scope: { title:'@progressTitle' },
         // template to insert for this directive
         // ng-transclude declares where original content goes and has 
         // access to parent scope


### PR DESCRIPTION
Defined the progressTitle in the template instead of the model to achieve same result.
This strategy allowed for data binding between the progressTitle and the controller scope by use of interpolation.

Note: Use of ' ' instead of " " is very important.
